### PR TITLE
issue/1: refactor pages to page bundles

### DIFF
--- a/refactor-pages-to-page-bundles.sh
+++ b/refactor-pages-to-page-bundles.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
-SCRIPTDIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)"
+# Helps migrate from v2.4.0 to v3.0.0
+#
+# Refactor a page named `X.md` to `content/<section>/X/index.md` to use the
+# new page bundles and featured image system
+#
+# - E.g. a post `content/post/X.md` is converted to `content/post/X/index.md`
 
 refactor_pages_to_page_bundles()
 {

--- a/refactor-pages-to-page-bundles.sh
+++ b/refactor-pages-to-page-bundles.sh
@@ -1,25 +1,27 @@
-#!/bin/bash
+#!/bin/sh
 
 SCRIPTDIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)"
 
 refactor_pages_to_page_bundles()
 {
-  cd "${SCRIPTDIR}/../"
+  if [ ! -d ./content/ ]; then
+    echo "Please run script from root of hugo site"
+  fi
   local files="$(find ./content/ -iname '*.md' -not -iname '*index.md' -not -ipath './content/home/*')"
   for file in ${files}; do
     local pagedir="${file%.md}"
 
     echo "${file} -> ${pagedir}/index.md"
-    [[ -d "${pagedir}" ]] || mkdir "${pagedir}"
+    if [ -d "${pagedir}" ]; then
+      mkdir "${pagedir}"
+    fi
 
     mv --no-target-directory "${file}" "${pagedir}/index.md"
   done
 }
 
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-    # Bash Strict Mode
-    set -eu -o pipefail
+# Bash Strict Mode
+set -eu
 
-    # set -x
-    refactor_pages_to_page_bundles "$@"
-fi
+# set -x
+refactor_pages_to_page_bundles "$@"

--- a/refactor-pages-to-page-bundles.sh
+++ b/refactor-pages-to-page-bundles.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SCRIPTDIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)"
+
+refactor_pages_to_page_bundles()
+{
+  cd "${SCRIPTDIR}/../"
+  local files="$(find ./content/ -iname '*.md' -not -iname '*index.md' -not -ipath './content/home/*')"
+  for file in ${files}; do
+    local pagedir="${file%.md}"
+
+    echo "${file} -> ${pagedir}/index.md"
+    [[ -d "${pagedir}" ]] || mkdir "${pagedir}"
+
+    mv --no-target-directory "${file}" "${pagedir}/index.md"
+  done
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    # Bash Strict Mode
+    set -eu -o pipefail
+
+    # set -x
+    refactor_pages_to_page_bundles "$@"
+fi


### PR DESCRIPTION
refactor-pages-to-page-bundles.sh

Helps migrate from v2.4.0 to v3.0.0

Refactor a page named `X.md` to `content/<section>/X/index.md` to use the new page bundles and featured image system

- E.g. a post `content/post/X.md` is converted to `content/post/X/index.md`

See results from using on hugo-academic:exampleSite:

- [branch](https://github.com/NGenetzky/hugo-academic/tree/1-refactor-pages-to-page-bundles)
- [commit](https://github.com/NGenetzky/hugo-academic/commit/b10348eac68f0eecbeecb98af1fe2deebec1e8af)
